### PR TITLE
Check if gui version of vim is running

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -5,7 +5,7 @@ map <Leader>l :call RunLastSpec()<CR>
 
 let s:plugin_path = expand("<sfile>:p:h:h")
 
-if has("gui_macvim")
+if has("gui_running") && has("gui_macvim")
   let g:rspec_command = "silent !" . s:plugin_path . "/bin/run_in_os_x_terminal 'rspec {spec}'"
 else
   let g:rspec_command = "!echo rspec {spec} && rspec {spec}"


### PR DESCRIPTION
As it stands, if MacVim is installed the script will try to run it, even if the app is not running. This is a fix for that.
