### PR TITLE
Remove default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,19 @@ This is a lightweight Rspec runner for Vim.
 
 Recommended installation with [vundle](https://github.com/gmarik/vundle):
 
-    Bundle 'thoughtbot/vim-rspec'
+```vim
+Bundle 'thoughtbot/vim-rspec'
+```
 
-## Default mappings
+## Recommended mappings
 
-    <leader>t - run the full spec file
-    <leader>s - run the spec file under the cursor
-    <leader>l - rerun the previous spec command
+```vim
+" Rspec.vim mappings
+map <Leader>t :call RunCurrentSpecFile()<CR>
+map <Leader>s :call RunNearestSpec()<CR>
+map <Leader>l :call RunLastSpec()<CR>
+
+```
 
 ## Configuration
 
@@ -20,7 +26,9 @@ Overwrite `g:rspec_command` variable to execute a custom command.
 
 Example:
 
-    let g:rspec_command = "!rspec --drb {spec}"
+```vim
+let g:rspec_command = "!rspec --drb {spec}"
+```
 
 ## License
 

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -1,8 +1,3 @@
-" Rspec mappings
-map <Leader>t :call RunCurrentSpecFile()<CR>
-map <Leader>s :call RunNearestSpec()<CR>
-map <Leader>l :call RunLastSpec()<CR>
-
 let s:plugin_path = expand("<sfile>:p:h:h")
 
 if has("gui_running") && has("gui_macvim")


### PR DESCRIPTION
These mappings are not necessarily going to be ingrained for
non-thoughtbotters.

I know for a fact that even within thoughtbot not everyone uses them: take
@rook's [dotfiles](https://github.com/r00k/dotfiles/blob/master/vimrc#L79) for example. I also use `<Leader>o` for the equivalent of
`RunNearestSpec` in my own workflow.

I've moved the previous Default mappings to the README as Recommended
mappings.
