### PR TITLE
Add support for vim-dispatch

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -4,7 +4,12 @@ if !exists("g:rspec_command")
   if has("gui_running") && has("gui_macvim")
     let g:rspec_command = "silent !" . s:plugin_path . "/bin/run_in_os_x_terminal 'rspec {spec}'"
   else
-    let g:rspec_command = "!echo rspec {spec} && rspec {spec}"
+    let s:cmd = "rspec {spec}"
+    if exists(":Dispatch")
+      let g:rspec_command = "Dispatch " . s:cmd
+    else
+      let g:rspec_command = "!echo " . s:cmd . " && " . s:cmd
+    endif
   endif
 endif
 


### PR DESCRIPTION
Will automatically `:Dispatch` the rspec command rather than `:!`ing it iff
[vim-dispatch](https://github.com/tpope/vim-dispatch) is available.
