### PR TITLE
add missing `call` when running specs from a non-spec file

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -19,7 +19,7 @@ function! RunCurrentSpecFile()
     call SetLastSpecCommand(l:spec)
     call RunSpecs(l:spec)
   else
-    RunLastSpec()
+    call RunLastSpec()
   endif
 endfunction
 
@@ -29,7 +29,7 @@ function! RunNearestSpec()
     call SetLastSpecCommand(l:spec)
     call RunSpecs(l:spec)
   else
-    RunLastSpec()
+    call RunLastSpec()
   endif
 endfunction
 


### PR DESCRIPTION
Running previous specs from a non-spec file breaks because of missing `call` keywords.
