### PR TITLE
Running the whole test suite doesn't require to be in a spec file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Bundle 'thoughtbot/vim-rspec'
 map <Leader>t :call RunCurrentSpecFile()<CR>
 map <Leader>s :call RunNearestSpec()<CR>
 map <Leader>l :call RunLastSpec()<CR>
-map <Leader>a :call RunAllSpecs()<CR>
 
 ```
 


### PR DESCRIPTION
Removed the check to make sure the user is in a spec file before running the whole test suite as this check isn't necessary.
