### PR TITLE
Dispatch support is load-order dependent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+* 2013-05-03 - Removed explicit support for Dispatch because it introduces  a
+  load order dependency. Set `g:rspec_command` in your .vimrc if you want to
+  use Dispatch or any other test runner.
 * 2013-04-11 - `RunCurrentSpecFile` and `RunNearestSpec` will fall back to
   `RunLastSpec` if not in spec file.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Example:
 let g:rspec_command = "!rspec --drb {spec}"
 ```
 
+This `g:rspec_command` variable can be used to support any number of test
+runners or pre-loaders. For example, you can use
+[Dispatch](https://github.com/tpope/dispatch) and
+[Zeus](https://github.com/burke/zeus) together with the following:
+
+```vim
+let g:rspec_command = "Dispatch zeus rspec {spec}"
+```
+
 ## License
 
 rspec.vim is copyright © 2013 thoughtbot. It is free software, and may be

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -1,15 +1,12 @@
 let s:plugin_path = expand("<sfile>:p:h:h")
 
 if !exists("g:rspec_command")
+  let s:cmd = "rspec {spec}"
+
   if has("gui_running") && has("gui_macvim")
-    let g:rspec_command = "silent !" . s:plugin_path . "/bin/run_in_os_x_terminal 'rspec {spec}'"
+    let g:rspec_command = "silent !" . s:plugin_path . "/bin/run_in_os_x_terminal '" . s:cmd . "'"
   else
-    let s:cmd = "rspec {spec}"
-    if exists(":Dispatch")
-      let g:rspec_command = "Dispatch " . s:cmd
-    else
-      let g:rspec_command = "!echo " . s:cmd . " && " . s:cmd
-    endif
+    let g:rspec_command = "!echo " . s:cmd . " && " . s:cmd
   endif
 endif
 


### PR DESCRIPTION
If you load vim-rspec before dispatch, vim-rspec won't know that dispatch is present. The fix is pretty simple -- change the load order, but it might not be obvious to all. In any case, load order dependencies aren't fun to manage. One solution would be to determine the `rspec_command` on first invocation.

Alternatively, we could drop direct support for dispatch from the plugin. In #12, the decision was made to leave it up to the user to set the proper test runner via the `g:rspec_command` configuration variable. Perhaps we should extend this to dispatch support as well?

What are your thoughts?
