### PR TITLE
Make writing current buffer optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ map <Leader>l :call RunLastSpec()<CR>
 
 ## Configuration
 
+### Rspec Command
+
 Overwrite `g:rspec_command` variable to execute a custom command.
 
 Example:
@@ -39,6 +41,15 @@ runners or pre-loaders. For example, you can use
 
 ```vim
 let g:rspec_command = "Dispatch zeus rspec {spec}"
+```
+
+### Write Before
+
+By default vim-rspec will `:write` the current buffer before running the spec
+command. If you would prefer to disable this, put the following in your vimrc:
+
+```vim
+let g:rspec_write_before = 0
 ```
 
 ## License

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -1,4 +1,5 @@
 let s:plugin_path = expand("<sfile>:p:h:h")
+let g:rspec_write_before = 1
 
 if !exists("g:rspec_command")
   let s:cmd = "rspec {spec}"
@@ -51,6 +52,8 @@ function! SetLastSpecCommand(spec)
 endfunction
 
 function! RunSpecs(spec)
-  write
+  if g:rspec_write_before
+    write
+  endif
   execute substitute(g:rspec_command, "{spec}", a:spec, "g")
 endfunction


### PR DESCRIPTION
I regularly use the "last spec" functionality by executing the plugin from while in the implementation file. In addition, I am usually running within a preloader ([zeus](https://github.com/burke/zeus) in this case), and writing the implementation file causes zeus to reload the file. This introduces an lag in running the spec. The following highlights the relative timing

``` shell
# Running without writing either spec of implementation file
time zeus rspec spec/models/advertiser/elastic_update/keyword_view_spec.rb:87
Finished in 0.38817 seconds
1 example, 0 failures
       1.33 real         0.46 user         0.03 sys

# Writing spec file has minimal impact on preloader
touch spec/models/advertiser/elastic_update/keyword_view_spec.rb && time zeus rspec spec/models/advertiser/elastic_update/keyword_view_spec.rb:87
Finished in 0.4218 seconds
1 example, 0 failures
        1.29 real         0.46 user         0.03 sys

# Writing the implementation file causes the rails env to be reloaded
touch app/models/advertiser/elastic_update/keyword_view.rb && time zeus rspec spec/models/advertiser/elastic_update/keyword_view_spec.rb:87
Finished in 0.27992 seconds
1 example, 0 failures
        8.28 real         0.48 user         0.03 sys
```

This pull makes writing the current buffer optional. This seems like the most straightforward solution, but another option would be to only write when in the spec file:

``` vim
function! RunSpecs(spec)
  if InSpecFile()
    write
  endif
  execute substitute(g:rspec_command, "{spec}", a:spec, "g")
endfunction
```
