### PR TITLE
Remove explicit `write` when running specs

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -51,6 +51,5 @@ function! SetLastSpecCommand(spec)
 endfunction
 
 function! RunSpecs(spec)
-  write
   execute substitute(g:rspec_command, "{spec}", a:spec, "g")
 endfunction


### PR DESCRIPTION
- Duplicates behavior provided by vim with `autowrite`
- Only writes the current file, which `autowrite` handles better
