### PR TITLE
Adding Bundler support

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -1,7 +1,15 @@
 let s:plugin_path = expand("<sfile>:p:h:h")
 
+function! BundleCheck()
+  if filereadable("Gemfile")
+    let s:cmd = "bundle exec rspec {spec}"
+  else
+    let s:cmd = "rspec {spec}"
+  endif
+endfunction
+
 if !exists("g:rspec_command")
-  let s:cmd = "rspec {spec}"
+  call BundleCheck()
 
   if has("gui_running") && has("gui_macvim")
     let g:rspec_command = "silent !" . s:plugin_path . "/bin/run_in_os_x_terminal '" . s:cmd . "'"


### PR DESCRIPTION
vim checks to see if a Gemfile is present in the directory. If it is, it will set s:cmd to 'bundle exec rspec {spec}'

Comments:
This is my first ever patch submission for a vim plugin. It's likely that there is a cleaner or more robust way to do this. For example, this will only work if Gemfile is in your PWD. But this works for my use case and I'm open to suggestions for improvement.

Thanks for putting this project together. I use it constantly.
