### PR TITLE
Fix contributors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Credits
 ![thoughtbot](http://thoughtbot.com/images/tm/logo.png)
 
 rspec.vim is maintained by [thoughtbot, inc](http://thoughtbot.com/community)
-and [contributors](/thoughtbot/vim-rspec/graphs/contributors) like you. Thank
-you!
+and [contributors](https://github.com/thoughtbot/vim-rspec/graphs/contributors)
+like you. Thank you!
 
 It was strongly influenced by Gary Bernhardt's [Destroy All
 Software](https://www.destroyallsoftware.com/screencasts) screencasts.


### PR DESCRIPTION
- Relative link was broken
- Relative links are ideal for files, not paths
- Source: https://github.com/blog/1395-relative-links-in-markup-files
