### PR TITLE
Use bundle exec

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -1,7 +1,7 @@
 let s:plugin_path = expand("<sfile>:p:h:h")
 
 if !exists("g:rspec_command")
-  let s:cmd = "rspec {spec}"
+  let s:cmd = "bundle exec rspec {spec}"
 
   if has("gui_running") && has("gui_macvim")
     let g:rspec_command = "silent !" . s:plugin_path . "/bin/run_in_os_x_terminal '" . s:cmd . "'"


### PR DESCRIPTION
Sometimes we can get the following errors

/Users/username/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/runtime.rb:33:in `block in setup': 
You have already activated rspec-core 2.14.4, but your Gemfile requires rspec-core 2.13.1. 
Using bundle exec may solve this. (Gem::LoadError)

Bundle exec solves such issues
