### PR TITLE
Use 'bundle exec rspec {spec}' if Gemfile exists

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -1,7 +1,11 @@
 let s:plugin_path = expand("<sfile>:p:h:h")
 
 if !exists("g:rspec_command")
-  let s:cmd = "rspec {spec}"
+  if filereadable("Gemfile")
+    let s:cmd = "bundle exec rspec {spec}"
+  else
+    let s:cmd = "rspec {spec}"
+  endif
 
   if has("gui_running") && has("gui_macvim")
     let g:rspec_command = "silent !" . s:plugin_path . "/bin/run_in_os_x_terminal '" . s:cmd . "'"


### PR DESCRIPTION
If you have more RSpec versions installed you can be sure that correct one is executed without using gemsets for RVM, rbenv...
