### PR TITLE
allow pattern matching of filenames to specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,29 @@ runners or pre-loaders. For example, you can use
 let g:rspec_command = "Dispatch zeus rspec {spec}"
 ```
 
+### Filename Pattern Matching
+
+The `g:rspec_patterns` variable can be passed a list of lists, which contain
+mappings of file names to spec names.  The first list element is a regex for
+matching the current file's name, and the second element is the spec file
+or directory to run.
+
+In this example, we're any time we run `RunCurrentSpecFile()` for a controller
+or javascript file, we run the `spec/features` directory.  Any time we run the
+command in a model file, we run that model's spec.
+
+Notice that the regex group matches from the first parameter can be
+interpolated into the second parameter with the syntax `{MATCH#}`, i.e.,
+`{MATCH1}` or `{MATCH3}`.
+
+```vim
+let g:rspec_patterns = [ 
+                       \ [ '\v^app/.+_controller\.rb$', "spec/features" ],
+                       \ [ '\v^app/.+(\.js|\.coffee)$', "spec/features" ],
+                       \ [ '\v^app/(.+)\.rb$', "spec/{MATCH1}_spec.rb" ]
+                     \ ]
+```
+
 Credits
 -------
 

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -10,6 +10,10 @@ if !exists("g:rspec_command")
   endif
 endif
 
+if !exists("g:rspec_patterns")
+  let g:rspec_patterns = []
+endif
+
 function! RunAllSpecs()
   let l:spec = "spec"
   call SetLastSpecCommand(l:spec)
@@ -19,6 +23,10 @@ endfunction
 function! RunCurrentSpecFile()
   if InSpecFile()
     let l:spec = @%
+    call SetLastSpecCommand(l:spec)
+    call RunSpecs(l:spec)
+  elseif InAlternateFile()
+    let l:spec = AlternateFile()
     call SetLastSpecCommand(l:spec)
     call RunSpecs(l:spec)
   else
@@ -52,4 +60,30 @@ endfunction
 
 function! RunSpecs(spec)
   execute substitute(g:rspec_command, "{spec}", a:spec, "g")
+endfunction
+
+function! InAlternateFile()
+  return AlternateFile() != -1
+endfunction
+
+function! AlternateFile()
+  for l:pattern in g:rspec_patterns
+    let l:matches = filter(matchlist(expand("%"), l:pattern[0] ), 'v:val != ""')
+
+    if len(l:matches) == 0
+      continue
+    endif
+
+    let l:alternate = l:pattern[1]
+
+    let l:i = 1
+    while l:i < len(l:matches)
+      let l:alternate = substitute(l:alternate, "{MATCH".i."}", l:matches[i], "")
+      let l:i += 1
+    endwhile
+
+    return l:alternate
+  endfor
+
+  return -1
 endfunction


### PR DESCRIPTION
Hey,

I've added the ability match file name patterns to their associated spec files.  For example `app/models/cast.rb` -> `spec/models/cast_spec.rb`.  It's kind of like `Guardfile` pattern matching.

First time ever writing vimscript, so let me know if there are any issues.

Anyway, below is the readme section to explain a bit more.

---

The `g:rspec_patterns` variable can be passed a list of lists, which contain
mappings of file names to spec names.  The first list element is a regex for
matching the current file's name, and the second element is the spec file
or directory to run.

In this example, we're any time we run `RunCurrentSpecFile()` for a controller
or javascript file, we run the `spec/features` directory.  Any time we run the
command in a model file, we run that model's spec.

Notice that the regex group matches from the first parameter can be
interpolated into the second parameter with the syntax `{MATCH#}`, i.e.,
`{MATCH1}` or `{MATCH3}`.

``` vim
let g:rspec_patterns = [ 
                       \ [ '\v^app/.+_controller\.rb$', "spec/features" ],
                       \ [ '\v^app/.+(\.js|\.coffee)$', "spec/features" ],
                       \ [ '\v^app/(.+)\.rb$', "spec/{MATCH1}_spec.rb" ]
                     \ ]
```
