### PR TITLE
Support for Windows Command Prompt

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -9,6 +9,8 @@ if !exists("g:rspec_command")
 
   if has("gui_running") && has("gui_macvim")
     let g:rspec_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
+  elseif has("win32") && fnamemodify(&shell, ':t') ==? "cmd.exe"
+    let g:rspec_command = "!cls && echo " . s:cmd . " && " . s:cmd
   else
     let g:rspec_command = "!clear && echo " . s:cmd . " && " . s:cmd
   endif


### PR DESCRIPTION
"clear" command does not exist in Windows Command Prompt (clear alias does exist in PowerShell). g:rspec_command changed to use cls on win32 platform, and if the tail of the shell path is "cmd.exe".
