### PR TITLE
add support for simultaneous g:rspec_command and g:rspec_runner

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -11,11 +11,11 @@ else
 endif
 
 if has("gui_running") && has("gui_macvim")
-  let g:rspec_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
+  let s:full_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
 elseif has("win32") && fnamemodify(&shell, ':t') ==? "cmd.exe"
-  let g:rspec_command = "!cls && echo " . s:cmd . " && " . s:cmd
+  let s:full_command = "!cls && echo " . s:cmd . " && " . s:cmd
 else
-  let g:rspec_command = "!clear && echo " . s:cmd . " && " . s:cmd
+  let s:full_command = "!clear && echo " . s:cmd . " && " . s:cmd
 endif
 
 function! RunAllSpecs()
@@ -59,5 +59,5 @@ function! SetLastSpecCommand(spec)
 endfunction
 
 function! RunSpecs(spec)
-  execute substitute(g:rspec_command, "{spec}", a:spec, "g")
+  execute substitute(s:full_command, "{spec}", a:spec, "g")
 endfunction


### PR DESCRIPTION
Want to be able to define both g:rspec_command and g:rspec_runner at the same time, but having g:rspec_command defined would mean g:rspec_runner would be ignored.

This fixes that.
