### PR TITLE
Allow setting full_command so we can use custom functions again

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -10,7 +10,9 @@ else
   let s:cmd = "rspec {spec}"
 endif
 
-if has("gui_running") && has("gui_macvim")
+if exists("g:rspec_full_command")
+  let s:full_command = g:rspec_full_command
+elseif has("gui_running") && has("gui_macvim")
   let s:full_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
 elseif has("win32") && fnamemodify(&shell, ':t') ==? "cmd.exe"
   let s:full_command = "!cls && echo " . s:cmd . " && " . s:cmd


### PR DESCRIPTION
With the current setup, we cannot call custom functions like `call SendToTmux(....)`, allow setting `g:rspec_full_command` so we can use something like

``` vim
let g:rspec_full_command = 'call SendToTmux("rspec {spec}\n")
```

and workflow like mentioned in this blog post http://robots.thoughtbot.com/running-specs-from-vim-sent-to-tmux-via-tslime can work with minor changes again.
