### PR TITLE
Support g:rspec_runner and g:rspec_command in GUI vim

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -4,15 +4,21 @@ if !exists("g:rspec_runner")
   let g:rspec_runner = "os_x_terminal"
 endif
 
-if !exists("g:rspec_command")
+if exists("g:rspec_command")
+  if has("gui_running") && has("gui_macvim")
+    let s:rspec_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . g:rspec_command . "'"
+  else
+    let s:rspec_command = g:rspec_command
+  endif
+else
   let s:cmd = "rspec {spec}"
 
   if has("gui_running") && has("gui_macvim")
-    let g:rspec_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
+    let s:rspec_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
   elseif has("win32") && fnamemodify(&shell, ':t') ==? "cmd.exe"
-    let g:rspec_command = "!cls && echo " . s:cmd . " && " . s:cmd
+    let s:rspec_command = "!cls && echo " . s:cmd . " && " . s:cmd
   else
-    let g:rspec_command = "!clear && echo " . s:cmd . " && " . s:cmd
+    let s:rspec_command = "!clear && echo " . s:cmd . " && " . s:cmd
   endif
 endif
 
@@ -57,5 +63,5 @@ function! SetLastSpecCommand(spec)
 endfunction
 
 function! RunSpecs(spec)
-  execute substitute(g:rspec_command, "{spec}", a:spec, "g")
+  execute substitute(s:rspec_command, "{spec}", a:spec, "g")
 endfunction


### PR DESCRIPTION
This change allows both `g:rspec_runner` and `g:rspec_command` to be used
together, which provides a way for GUI vim to run a custom command while
providing a specific runner.
