### PR TITLE
Allow for override of gui external runner

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -4,8 +4,12 @@ if !exists("g:rspec_runner")
   let g:rspec_runner = "os_x_terminal"
 endif
 
+if !exists("g:rspec_use_external_runner")
+  let g:rspec_use_external_runner = 1
+endif
+
 if exists("g:rspec_command")
-  if has("gui_running") && has("gui_macvim")
+  if has("gui_running") && has("gui_macvim") && g:rspec_use_external_runner
     let s:rspec_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . g:rspec_command . "'"
   else
     let s:rspec_command = g:rspec_command


### PR DESCRIPTION
I've been using vim-rspec for a while and it's awesome, but the recent update to allow for both `g:rspec_runner` and `g:rspec_command` breaks my current workflow that I think others might also have: MacVim and tmux. Currently, all commands when run in gui vim are executed using the configured runner. This means that, even with a custom command, gui vim will not be able to execute anything inside of vim to externally run the command.

I added a global variable that allows the user to explicitly state if they do or do not want to use a runner script. This variable is set to true by default so that the current behavior without setting either `rspec_command` or `rspec_runner` remains the same.

While I don't think this is necessarily the best way to do this, it is "a way" and it requires minimal change. If there is a better way to do this, please let me know; if not, I'd be happy to also update the README with references to this variable.
