### PR TITLE
Add ability to change rspec run command after opening vim

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -22,6 +22,14 @@ else
   endif
 endif
 
+function! SetSpecCommand(new_command)
+  let s:rspec_command = a:new_command
+endfunction
+
+function! GetSpecCommand()
+  return s:rspec_command
+endfunction
+
 function! RunAllSpecs()
   let l:spec = "spec"
   call SetLastSpecCommand(l:spec)


### PR DESCRIPTION
This pull request allows changing of the rspec_command after vim is started. In my case this is useful to be able to toggle whether vim-rspec should use spring via this command:

```
:command Spring :call SpringToggle()
function! SpringToggle()
  let s:current_command = GetSpecCommand()
  if s:current_command == s:springon
    call SetSpecCommand(s:springoff)
    echo "Spring disabled"
  else
    call SetSpecCommand(s:springon)
    echo "Spring enabled"
  endif
endfunction
```
