### PR TITLE
Feature/add options

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -11,7 +11,7 @@ if exists("g:rspec_command")
     let s:rspec_command = g:rspec_command
   endif
 else
-  let s:cmd = "rspec {spec}"
+  let s:cmd = "rspec {options} {spec}"
 
   if has("gui_running") && has("gui_macvim")
     let s:rspec_command = "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . s:cmd . "'"
@@ -32,15 +32,31 @@ endfunction
 
 function! RunAllSpecs()
   let l:spec = "spec"
-  call SetLastSpecCommand(l:spec)
-  call RunSpecs(l:spec)
+  call SetLastSpecCommand(l:spec, '')
+  call RunSpecs(l:spec, '')
+endfunction
+
+function! RunAllSpecsWithOptions(options)
+  let l:spec = "spec"
+  call SetLastSpecCommand(l:spec, a:options)
+  call RunSpecs(l:spec, a:options)
 endfunction
 
 function! RunCurrentSpecFile()
   if InSpecFile()
     let l:spec = @%
-    call SetLastSpecCommand(l:spec)
-    call RunSpecs(l:spec)
+    call SetLastSpecCommand(l:spec, '')
+    call RunSpecs(l:spec, '')
+  else
+    call RunLastSpec()
+  endif
+endfunction
+
+function! RunCurrentSpecFileWithOptions(options)
+  if InSpecFile()
+    let l:spec = @%
+    call SetLastSpecCommand(l:spec, a:options)
+    call RunSpecs(l:spec, a:options)
   else
     call RunLastSpec()
   endif
@@ -49,8 +65,18 @@ endfunction
 function! RunNearestSpec()
   if InSpecFile()
     let l:spec = @% . ":" . line(".")
-    call SetLastSpecCommand(l:spec)
-    call RunSpecs(l:spec)
+    call SetLastSpecCommand(l:spec, '')
+    call RunSpecs(l:spec, '')
+  else
+    call RunLastSpec()
+  endif
+endfunction
+
+function! RunNearestSpecWithOptions(options)
+  if InSpecFile()
+    let l:spec = @% . ":" . line(".")
+    call SetLastSpecCommand(l:spec, a:options)
+    call RunSpecs(l:spec, a:options)
   else
     call RunLastSpec()
   endif
@@ -58,7 +84,11 @@ endfunction
 
 function! RunLastSpec()
   if exists("s:last_spec_command")
-    call RunSpecs(s:last_spec_command)
+    if exists("s:last_spec_options")
+      call RunSpecs(s:last_spec_command, s:last_spec_options)
+    else
+      call RunSpecs(s:last_spec_command, '')
+    endif
   endif
 endfunction
 
@@ -66,10 +96,12 @@ function! InSpecFile()
   return match(expand("%"), "_spec.rb$") != -1
 endfunction
 
-function! SetLastSpecCommand(spec)
+function! SetLastSpecCommand(spec, options)
   let s:last_spec_command = a:spec
+  let s:last_spec_options = a:options
 endfunction
 
-function! RunSpecs(spec)
-  execute substitute(s:rspec_command, "{spec}", a:spec, "g")
+function! RunSpecs(spec, options)
+  let l:with_options = substitute(s:rspec_command, "{options}", a:options, "g")
+  execute substitute(l:with_options, "{spec}", a:spec, "g")
 endfunction


### PR DESCRIPTION
Note: requires modifying of rspec_command for this to work although should be backwards compatible.

Added the ability to pass different options into the various rspec commands. In order to demonstrate the usefulness of this, consider my test bindings:

```
map <Leader>t :call RunCurrentSpecFile()<CR> " Run all specs in current file
map <Leader>T :call RunCurrentSpecFileWithOptions("--tag=~integration")<CR> " Run all specs in current file apart from ones tagged as integration (for me, slow selenium tests)
map <Leader>s :call RunNearestSpec()<CR> " Run nearest spec
map <Leader>l :call RunLastSpec()<CR> " Run last spec (should work fine with options)
map <Leader>a :call RunAllSpecsWithOptions("--tag=~integration")<CR> " Run all specs apart from integration ones
map <Leader>A :call RunAllSpecs()<CR> " Run all specs
```

Would be interested to see how others use this, I find it really useful.
