### PR TITLE
Adds delay to activate MacVim after iTerm command

### DIFF
--- a/bin/os_x_iterm
+++ b/bin/os_x_iterm
@@ -17,6 +17,8 @@ on run argv
     end tell
   end tell
 
+  delay 0.02
+
   tell application "MacVim"
     activate
   end tell

--- a/bin/os_x_terminal
+++ b/bin/os_x_terminal
@@ -22,6 +22,8 @@ on run argv
     activate
   end tell
 
+  delay 0.02
+
   tell application "MacVim"
     activate
   end tell


### PR DESCRIPTION
Since Yosemite the reactivation of MacVim after running a iTerm command
through vim-rspec has been inconsistent. Adding this short 0.02 second
delay makes this behave consistently. This fixes #71
