### PR TITLE
Track last spec line separately from last file

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -7,31 +7,25 @@ if !exists("g:rspec_runner")
 endif
 
 function! RunAllSpecs()
-  let s:last_spec_location = "spec"
-  call s:RunSpecs(s:last_spec_location)
+  call s:RunSpecs("spec")
 endfunction
 
 function! RunCurrentSpecFile()
   if s:InSpecFile()
-    let s:last_spec_location = s:CurrentFilePath()
-    call s:RunSpecs(s:last_spec_location)
-  else
-    call RunLastSpec()
+    let s:last_spec_file = s:CurrentFilePath()
+    call s:RunSpecs(s:last_spec_file)
+  elseif exists("s:last_spec_file")
+    call s:RunSpecs(s:last_spec_file)
   endif
 endfunction
 
 function! RunNearestSpec()
   if s:InSpecFile()
-    let s:last_spec_location = s:CurrentFilePath() . ":" . line(".")
-    call s:RunSpecs(s:last_spec_location)
-  else
-    call RunLastSpec()
-  endif
-endfunction
-
-function! RunLastSpec()
-  if exists("s:last_spec_location")
-    call s:RunSpecs(s:last_spec_location)
+    let s:last_spec_file = s:CurrentFilePath()
+    let s:last_spec_file_with_line = s:last_spec_file . ":" . line(".")
+    call s:RunSpecs(s:last_spec_file_with_line)
+  elseif exists("s:last_spec_file_with_line")
+    call s:RunSpecs(s:last_spec_file_with_line)
   endif
 endfunction
 

--- a/t/rspec_test.vim
+++ b/t/rspec_test.vim
@@ -92,3 +92,56 @@ describe "RunSpecs"
     end
   end
 end
+
+describe "RunCurrentSpecFile"
+  context "when not in a spec file"
+    before
+      let g:rspec_command = "!rspec {spec}"
+    end
+
+    after
+      unlet g:rspec_command
+    end
+
+    context "when line number is not set"
+      it "runs the last spec file"
+        call Set("s:last_spec_file", "model_spec.rb")
+
+        call Call("RunCurrentSpecFile")
+
+        Expect Ref("s:rspec_command") == "!rspec model_spec.rb"
+      end
+    end
+
+    context "when line number is set"
+      it "runs the last spec file"
+        call Set("s:last_spec_file", "model_spec.rb")
+        call Set("s:last_spec_line", 42)
+
+        call Call("RunCurrentSpecFile")
+
+        Expect Ref("s:rspec_command") == "!rspec model_spec.rb"
+      end
+    end
+  end
+end
+
+describe "RunNearestSpec"
+  context "not in a spec file"
+    before
+      let g:rspec_command = "!rspec {spec}"
+    end
+
+    after
+      unlet g:rspec_command
+    end
+
+    it "runs the last spec file with line"
+      call Set("s:last_spec_file_with_line", "model_spec.rb:42")
+
+      call Call("RunNearestSpec")
+
+      Expect Ref("s:rspec_command") == "!rspec model_spec.rb:42"
+    end
+  end
+end


### PR DESCRIPTION
Updates `RunNearestSpec` to always run the last nearest spec, and
`RunCurrentSpecFile` to always run the last entire file.

An example workflow:

1. Write a test, run only it with `<leader>s` (`RunNearestSpec`)
1. Switch to source file, implement change, run single test again with
   `<leader>s` (`RunNearestSpec`)
1. While still in the source file, run the entire test file with
   `<leader>t` (`RunCurrentSpecFile`)
1. Profit

I've never used vspec before, so there's probably some jankiness there that could be cleaned up. Any feedback about it or Vimscript best practices would be amazing :heart_eyes:.