### PR TITLE
Restore RunLastSpec()

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -7,12 +7,14 @@ if !exists("g:rspec_runner")
 endif
 
 function! RunAllSpecs()
-  call s:RunSpecs("spec")
+  let s:last_spec = "spec"
+  call s:RunSpecs(s:last_spec)
 endfunction
 
 function! RunCurrentSpecFile()
   if s:InSpecFile()
     let s:last_spec_file = s:CurrentFilePath()
+    let s:last_spec = s:last_spec_file
     call s:RunSpecs(s:last_spec_file)
   elseif exists("s:last_spec_file")
     call s:RunSpecs(s:last_spec_file)
@@ -23,9 +25,16 @@ function! RunNearestSpec()
   if s:InSpecFile()
     let s:last_spec_file = s:CurrentFilePath()
     let s:last_spec_file_with_line = s:last_spec_file . ":" . line(".")
+    let s:last_spec = s:last_spec_file_with_line
     call s:RunSpecs(s:last_spec_file_with_line)
   elseif exists("s:last_spec_file_with_line")
     call s:RunSpecs(s:last_spec_file_with_line)
+  endif
+endfunction
+
+function! RunLastSpec()
+  if exists("s:last_spec")
+    call s:RunSpecs(s:last_spec)
   endif
 endfunction
 

--- a/t/rspec_test.vim
+++ b/t/rspec_test.vim
@@ -145,3 +145,31 @@ describe "RunNearestSpec"
     end
   end
 end
+
+describe "RunLastSpec"
+  before
+    let g:rspec_command = "!rspec {spec}"
+  end
+
+  after
+    unlet g:rspec_command
+  end
+
+  context "when s:last_spec is set"
+    it "executes the last spec"
+      call Set("s:last_spec", "model_spec.rb:42")
+
+      call Call("RunLastSpec")
+
+      Expect Ref("s:rspec_command") == "!rspec model_spec.rb:42"
+    end
+  end
+end
+
+describe "RunAllSpecs"
+  it "sets s:last_spec to 'spec'"
+    call Call("RunAllSpecs")
+
+    Expect Ref("s:last_spec") == "spec"
+  end
+end


### PR DESCRIPTION
`RunLastSpec()` was removed in 6a39ba7 because I didn't realize it was a
feature that was exposed to the end user. This brings it back and
incorporates the changes to track last file and line separately.