### PR TITLE
Allow spaces in plugin path

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -77,7 +77,7 @@ function! s:CurrentFilePath()
 endfunction
 
 function! s:GuiCommand(command)
-  return "silent !" . s:plugin_path . "/bin/" . g:rspec_runner . " '" . a:command . "'"
+  return "silent ! '" . s:plugin_path . "/bin/" . g:rspec_runner . "' '" . a:command . "'"
 endfunction
 
 function! s:ClearCommand()


### PR DESCRIPTION
This necessary if you (for example) have your vim config symlinked to a DropBox path where one of the folder names has a space in it.