### PR TITLE
Run commands in current iTerm tab

### DIFF
--- a/bin/os_x_iterm
+++ b/bin/os_x_iterm
@@ -11,7 +11,7 @@ on run argv
     activate
 
     tell _terminal
-      tell the last session
+      tell the current session
         write text (item 1 of argv)
       end tell
     end tell


### PR DESCRIPTION
iTerm runner was using the last tab, rather that the current tab.