### PR TITLE
Removing "spec" as the last_spec in RunAllSpecs

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -7,7 +7,7 @@ if !exists("g:rspec_runner")
 endif
 
 function! RunAllSpecs()
-  let s:last_spec = "spec"
+  let s:last_spec = ""
   call s:RunSpecs(s:last_spec)
 endfunction
 

--- a/t/rspec_test.vim
+++ b/t/rspec_test.vim
@@ -170,6 +170,6 @@ describe "RunAllSpecs"
   it "sets s:last_spec to 'spec'"
     call Call("RunAllSpecs")
 
-    Expect Ref("s:last_spec") == "spec"
+    Expect Ref("s:last_spec") == ""
   end
 end


### PR DESCRIPTION
Forcing `rspec spec` in RunAllSpecs overrides `--default-path` in the local `.rspec` config, and "spec" is RSpec's default anyway if the default path is not explicitly set.
