### PR TITLE
Add Neovim details in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Or, [Dispatch](https://github.com/tpope/vim-dispatch) and
 let g:rspec_command = "compiler rspec | set makeprg=zeus | Make rspec {spec}"
 ```
 
+#### Neovim
+
+Neovim has [a new behavior for handling bang commands](https://github.com/neovim/neovim/issues/1496#issuecomment-63691483).
+Because of this, using `vim-rspec` with Neovim will output the results of the specs, but the output will be missing color.
+
+In order to fix this, you can use the [Custom Command](https://github.com/thoughtbot/vim-rspec#custom-command) option to run the specs with the new terminal commands that Neovim provides.
+
+```vim
+let g:rspec_command = "term rspec #{spec}"
+```
+
 ### Custom runners
 
 Overwrite the `g:rspec_runner` variable to set a custom launch script. At the


### PR DESCRIPTION
I've been making the switch over to Neovim (just to see if it's a viable option).

So far so good, but I found out that Neovim doesn't use bang commands the same as Vim. As such - the runner has to be adjusted to use the new format for terminal commands.

Using the default configuration doesn't output colors, because the bang command is used to [open a pipe, read output and display to the user](https://github.com/neovim/neovim/issues/1496#issuecomment-63691483)
<img width="779" alt="screen shot 2016-02-14 at 12 17 49 am" src="https://cloud.githubusercontent.com/assets/1141717/13032236/82ee15be-d2b0-11e5-9019-54958535e0d3.png">

The `term` command has to be used instead:

``` vim
let g:rspec_command = "term rspec #{spec}"
```

<img width="642" alt="screen shot 2016-02-14 at 12 22 13 am" src="https://cloud.githubusercontent.com/assets/1141717/13032258/0a92b466-d2b1-11e5-93d6-9f97ee56be0a.png">

Adding documentation here so that others making the switch will know about the needed adjustment!
Thanks for an excellent plugin!
