### PR TITLE
Update thoughtbot.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ rake
 Credits
 -------
 
-![thoughtbot](http://thoughtbot.com/images/tm/logo.png)
+![thoughtbot](https://thoughtbot.com/logo.png)
 
-rspec.vim is maintained by [thoughtbot, inc](http://thoughtbot.com/community)
+rspec.vim is maintained by [thoughtbot's Vim enthusiasts](https://thoughtbot.com/upcase/vim)
 and [contributors](https://github.com/thoughtbot/vim-rspec/graphs/contributors)
 like you. Thank you!
 
@@ -104,7 +104,7 @@ Software](https://www.destroyallsoftware.com/screencasts) screencasts.
 
 ## License
 
-rspec.vim is copyright © 2014 thoughtbot. It is free software, and may be
+rspec.vim is copyright © 2016 thoughtbot. It is free software, and may be
 redistributed under the terms specified in the `LICENSE` file.
 
 The names and logos for thoughtbot are trademarks of thoughtbot, inc.


### PR DESCRIPTION
The previous links were to pages that now redirect. Provide more recent, relevant options.