### PR TITLE
Produce relative paths consistently

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -73,7 +73,7 @@ function! s:DefaultTerminalCommand()
 endfunction
 
 function! s:CurrentFilePath()
-  return @%
+  return fnamemodify(expand("%"), ":~:.")
 endfunction
 
 function! s:GuiCommand(command)


### PR DESCRIPTION
http://stackoverflow.com/a/24463362/555384

There are cases where `@%` will produce both relative and absolute
paths, this change will make the behavior consistent.

More specifically, even if you open the initial file relatively, some plugins
(like rails.vim) target the opening of related files (using :A from a
model for example) absolutely.  In this case `@%` will go from producing
`spec/model/thing_spec.rb` to producing
`/Users/jon/..../spec/model/thing_spec.rb`, simply because you used a
feature of an unrelated plugin.

The specific case this is breaking for me, is that when running specs in
a VM, the relative path is key.  Absolute paths referencing the host
machine obviously will blow up when attempting to run in a VM.