### PR TITLE
Backfill test cases which depend on knowing if the current file is a spec file or not

### DIFF
--- a/t/rspec_test.vim
+++ b/t/rspec_test.vim
@@ -94,48 +94,100 @@ describe "RunSpecs"
 end
 
 describe "RunCurrentSpecFile"
-  context "when not in a spec file"
+  before
+    let g:rspec_command = "!rspec {spec}"
+  end
+
+  after
+    unlet g:rspec_command
+  end
+
+  context "when in a spec file"
     before
-      let g:rspec_command = "!rspec {spec}"
+      new
+      file controller_spec.rb
     end
 
     after
-      unlet g:rspec_command
+      bdelete!
     end
 
-    context "when line number is not set"
-      it "runs the last spec file"
-        call Set("s:last_spec_file", "model_spec.rb")
+    it "runs the current spec file"
+      call Set("s:last_spec_file", "model_spec.rb")
 
-        call Call("RunCurrentSpecFile")
+      call Call("RunCurrentSpecFile")
 
-        Expect Ref("s:rspec_command") == "!rspec model_spec.rb"
-      end
+      Expect Ref("s:rspec_command") == "!rspec controller_spec.rb"
     end
 
-    context "when line number is set"
-      it "runs the last spec file"
-        call Set("s:last_spec_file", "model_spec.rb")
-        call Set("s:last_spec_line", 42)
+    it "sets last_spec_file to the current file"
+      call Set("s:last_spec_file", "model_spec.rb")
 
-        call Call("RunCurrentSpecFile")
+      call Call("RunCurrentSpecFile")
 
-        Expect Ref("s:rspec_command") == "!rspec model_spec.rb"
-      end
+      Expect Ref("s:last_spec_file") ==  "controller_spec.rb"
+    end
+  end
+
+  context "when not in a spec file"
+    it "runs the last spec file"
+      call Set("s:last_spec_file", "model_spec.rb")
+
+      call Call("RunCurrentSpecFile")
+
+      Expect Ref("s:rspec_command") == "!rspec model_spec.rb"
     end
   end
 end
 
 describe "RunNearestSpec"
-  context "not in a spec file"
+  before
+    let g:rspec_command = "!rspec {spec}"
+  end
+
+  after
+    unlet g:rspec_command
+  end
+
+  context "when in a spec file"
     before
-      let g:rspec_command = "!rspec {spec}"
+      new
+      file controller_spec.rb
+      put =[
+          \   'it \"is tautological\" do',
+          \   '  expect(true).to eq',
+          \   'end',
+          \   '',
+          \   'it \"is optimistic\" do',
+          \   '  expect(1 + 1).to eq 3',
+          \   'end',
+          \ ]
+      5 " jump to the start of the second spec
     end
 
     after
-      unlet g:rspec_command
+      bdelete!
     end
 
+    it "runs the current spec file at the current line"
+      call Set("s:last_spec_file_with_line", "model_spec.rb:42")
+      call Set("s:last_spec_file", "model_spec.rb")
+
+      call Call("RunNearestSpec")
+
+      Expect Ref("s:rspec_command") == "!rspec controller_spec.rb:5"
+    end
+
+    it "sets last_spec_file to the current file"
+      call Set("s:last_spec_file", "model_spec.rb")
+
+      call Call("RunNearestSpec")
+
+      Expect Ref("s:last_spec_file") ==  "controller_spec.rb"
+    end
+  end
+
+  context "not in a spec file"
     it "runs the last spec file with line"
       call Set("s:last_spec_file_with_line", "model_spec.rb:42")
 
@@ -167,6 +219,24 @@ describe "RunLastSpec"
 end
 
 describe "RunAllSpecs"
+  before
+    let g:rspec_command = "!rspec {spec}"
+  end
+
+  after
+    unlet g:rspec_command
+  end
+
+  it "runs all specs"
+    call Set("s:last_spec", "model_spec.rb:42")
+    call Set("s:last_spec_file", "model_spec.rb")
+    call Set("s:last_spec_file_with_line", "model_spec.rb:42")
+
+    call Call("RunAllSpecs")
+
+    Expect Ref("s:rspec_command") == "!rspec spec"
+  end
+
   it "sets s:last_spec to 'spec'"
     call Call("RunAllSpecs")
 


### PR DESCRIPTION
Looking at the specs it seemed like there were some missing test cases, and some superfluous test cases.

This PR adds in test coverage for the scenarios where the context is currently a spec file, and deletes some test cases which refer to variables not actually used in the code. 

Arguably the tests which assert that variables are set (e.g. `Expect Ref("s:last_spec_file") ==  "controller_spec.rb"`) are testing implementation details rather than behaviour. 

An alternative way of writing this would be to have integration tests which e.g. assert that if RunLastSpec is called after RunCurrentTestFile then the correct file gets run. 

This is my first attempt at writing vspec tests, so please let me know if the style isn't right.
