### PR TITLE
Add support for running only failing specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ map <Leader>t :call RunCurrentSpecFile()<CR>
 map <Leader>s :call RunNearestSpec()<CR>
 map <Leader>l :call RunLastSpec()<CR>
 map <Leader>a :call RunAllSpecs()<CR>
+map <Leader>f :call RunFailingSpecs()<CR>
 ```
 
 ### Custom command

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -38,6 +38,11 @@ function! RunLastSpec()
   endif
 endfunction
 
+function! RunFailingSpecs()
+  let s:last_spec = "spec --only-failures"
+  call s:RunSpecs(s:last_spec)
+endfunction
+
 " === local functions ===
 
 function! s:RunSpecs(spec_location)

--- a/t/rspec_test.vim
+++ b/t/rspec_test.vim
@@ -173,3 +173,25 @@ describe "RunAllSpecs"
     Expect Ref("s:last_spec") == "spec"
   end
 end
+
+describe "RunFailingSpecs"
+  before
+    let g:rspec_command = "!rspec {spec}"
+  end
+
+  after
+    unlet g:rspec_command
+  end
+
+  it "runs failing specs"
+    call Call("RunFailingSpecs")
+
+    Expect Ref("s:rspec_command") == "!rspec spec --only-failures"
+  end
+
+  it "sets s:last_spec to 'spec --only-failures'"
+    call Call("RunFailingSpecs")
+
+    Expect Ref("s:last_spec") == "spec --only-failures"
+  end
+end


### PR DESCRIPTION
Uses the --only-failures flag which was introduced in RSpec 3.3
https://relishapp.com/rspec/rspec-core/v/3-5/docs/command-line/only-failures
