### PR TITLE
Add support for fish (shell) 🐠

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -69,7 +69,7 @@ function! s:RspecCommandProvided()
 endfunction
 
 function! s:DefaultTerminalCommand()
-  return "!" . s:ClearCommand() . " && echo " . s:default_command . " && " . s:default_command
+  return "!" . s:ClearCommand() . s:AndCommand() . "echo " . s:default_command . s:AndCommand() . s:default_command
 endfunction
 
 function! s:CurrentFilePath()
@@ -85,6 +85,14 @@ function! s:ClearCommand()
     return "cls"
   else
     return "clear"
+  endif
+endfunction
+
+function! s:AndCommand()
+  if &shell[-4:] == "fish"
+    return "; and "
+  else
+    return " && "
   endif
 endfunction
 


### PR DESCRIPTION
I'd like to add support for the fish shell.  

Because this plugin runs system commands, many of the calls need to be mapped.  (This is already done for the `clear` command, for example.)

Fish (notoriously) does not support `&&` in system calls.  The prefered method is `COMMAND; and COMMAND2`

`if &shell[-4:] == "fish"` is not incredibly elegant, but it's not terrible?  If you are able to review, would love to hear your thoughts.