### PR TITLE
Let user specify an option to redraw! after running specs for integration with vim-plumber

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -44,6 +44,7 @@ function! s:RunSpecs(spec_location)
   let s:rspec_command = substitute(s:RspecCommand(), "{spec}", a:spec_location, "g")
 
   execute s:rspec_command
+  redraw!
 endfunction
 
 function! s:InSpecFile()

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -44,7 +44,9 @@ function! s:RunSpecs(spec_location)
   let s:rspec_command = substitute(s:RspecCommand(), "{spec}", a:spec_location, "g")
 
   execute s:rspec_command
-  redraw!
+  if s:UserWantsRedrawAfterSpecs()
+    redraw!
+  endif
 endfunction
 
 function! s:InSpecFile()
@@ -67,6 +69,10 @@ endfunction
 
 function! s:RspecCommandProvided()
   return exists("g:rspec_command")
+endfunction
+
+function! s:UserWantsRedrawAfterSpecs()
+  return exists("g:redraw_after_specs")
 endfunction
 
 function! s:DefaultTerminalCommand()


### PR DESCRIPTION
Very useful to integrate this plugin with [vim-plumber](https://github.com/stefanoverna/vim-plumber).
In that plugin, you can send commands to a pipe that will execute them, useful for sending `bundle exec rspec` to it and execute tests in background in another terminal (or tmux pane ;) ).

Without my modifications, user can specify
```bash
#! /usr/bin/env bash
DEFAULT_PIPE_NAME=".plumber"
PIPE_NAME="${1:-$DEFAULT_PIPE_NAME}"

if [ ! -p $PIPE_NAME ]; then
  echo "Created pipe ${PIPE_NAME}..."
  mkfifo $PIPE_NAME
fi

echo "Waiting for commands!"

while :; do
  while read -r cmd; do
    echo "Running $cmd..."
    sh -c "$cmd"
  done <"$PIPE_NAME"
done
```
as their `read_pipe.sh` and `let g:rspec_command = "silent ! echo \"rspec {spec}\" > .plumber &"` in their vimrc to execute commands to pipe. The problem with this is that user needs to press `Enter` after doing this. If he specifies `let g:redraw_after_specs = 1` in vimrc, vim-rspec will redraw so user will keep focused in writing code and running specs in background.

Practical example:
```vimscript
" Maps to run Rspec easily
nnoremap <leader>a :call RunAllSpecs()<CR>
nnoremap <leader>l :call RunLastSpec()<CR>
nnoremap <leader>; :call RunNearestSpec()<CR>
nnoremap <leader>' :call RunCurrentSpecFile()<CR>
 
" Integrate vim-rspec with vim-plumber. Comment this if you don't use
" vim-plumber
let g:rspec_command = "silent ! echo \"rspec {spec}\" > .plumber &"
let g:redraw_after_specs = 1
" Protip: This is my actual .vimrc configuration.
```
Then use `<leader>;` to execute `vim-rspec` function that will be read by `vim-plumber` and executed in background.

I know it's a very specific purpose but with allowing user to specify it he wants this behaviour I find it very useful.