### PR TITLE
Support running examples by visual selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add your preferred key mappings to your `.vimrc` file.
 ```vim
 " RSpec.vim mappings
 map <Leader>t :call RunCurrentSpecFile()<CR>
-map <Leader>s :call RunNearestSpec()<CR>
+map <Leader>e :call RunExamples()<CR>         " runs examples under cursor or in visual selection
 map <Leader>l :call RunLastSpec()<CR>
 map <Leader>a :call RunAllSpecs()<CR>
 ```

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -21,14 +21,21 @@ function! RunCurrentSpecFile()
   endif
 endfunction
 
+" Preserved for backwards compatibility
 function! RunNearestSpec()
+  call RunExamples()
+endfunction
+
+function! RunExamples() range
   if s:InSpecFile()
+    let line_arg = ":" . join(range(a:firstline, a:lastline), ":")
+
     let s:last_spec_file = s:CurrentFilePath()
-    let s:last_spec_file_with_line = s:last_spec_file . ":" . line(".")
-    let s:last_spec = s:last_spec_file_with_line
-    call s:RunSpecs(s:last_spec_file_with_line)
-  elseif exists("s:last_spec_file_with_line")
-    call s:RunSpecs(s:last_spec_file_with_line)
+    let s:last_spec_example = s:last_spec_file . line_arg
+    let s:last_spec = s:last_spec_examples
+    call s:RunSpecs(s:last_spec_examples)
+  elseif exists("s:last_spec_examples")
+    call s:RunSpecs(s:last_spec_examples)
   endif
 endfunction
 

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -31,7 +31,7 @@ function! RunExamples() range
     let line_arg = ":" . join(range(a:firstline, a:lastline), ":")
 
     let s:last_spec_file = s:CurrentFilePath()
-    let s:last_spec_example = s:last_spec_file . line_arg
+    let s:last_spec_examples = s:last_spec_file . line_arg
     let s:last_spec = s:last_spec_examples
     call s:RunSpecs(s:last_spec_examples)
   elseif exists("s:last_spec_examples")


### PR DESCRIPTION
I've modified the public function `RunNearestSpec()` to support visual selections. It behaves the same as before in Normal mode, but now runs, _e.g.,_ `$ rspec <spec_file>:8:9:10:11:12` for a visual selection spanning lines 8–12.

I also changed the name to `RunExamples()` because it seemed semantically more correct to me, but kept the old one in the interest of backwards compatibility.

I did not, however, run the tests or add a test for this new function. I'd be happy to, but I'd like to make sure that the maintainers are interested in pulling this change before committing to all that work.