### PR TITLE
Add support for alternative rspec command

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -6,12 +6,14 @@ if !exists("g:rspec_runner")
   let g:rspec_runner = "os_x_terminal"
 endif
 
-function! RunAllSpecs()
+function! RunAllSpecs(...)
   let s:last_spec = ""
+  call s:GetCommandChoice(a:0, a:000)
   call s:RunSpecs(s:last_spec)
 endfunction
 
-function! RunCurrentSpecFile()
+function! RunCurrentSpecFile(...)
+  call s:GetCommandChoice(a:0, a:000)
   if s:InSpecFile()
     let s:last_spec_file = s:CurrentFilePath()
     let s:last_spec = s:last_spec_file
@@ -21,7 +23,8 @@ function! RunCurrentSpecFile()
   endif
 endfunction
 
-function! RunNearestSpec()
+function! RunNearestSpec(...)
+  call s:GetCommandChoice(a:0, a:000)
   if s:InSpecFile()
     let s:last_spec_file = s:CurrentFilePath()
     let s:last_spec_file_with_line = s:last_spec_file . ":" . line(".")
@@ -32,13 +35,22 @@ function! RunNearestSpec()
   endif
 endfunction
 
-function! RunLastSpec()
+function! RunLastSpec(...)
+  call s:GetCommandChoice(a:0, a:000)
   if exists("s:last_spec")
     call s:RunSpecs(s:last_spec)
   endif
 endfunction
 
 " === local functions ===
+
+function! s:GetCommandChoice(count, arguments)
+  if a:count == 1
+    let g:command_choice = a:arguments[0]
+  else
+    let g:command_choice = "standard"
+  end
+endfunction
 
 function! s:RunSpecs(spec_location)
   let s:rspec_command = substitute(s:RspecCommand(), "{spec}", a:spec_location, "g")
@@ -50,11 +62,24 @@ function! s:InSpecFile()
   return match(expand("%"), "_spec.rb$") != -1
 endfunction
 
+function! s:GetChosenCommand()
+  if g:command_choice == "standard"
+    let l:chosen_command = g:rspec_command
+  elseif g:command_choice == "0"
+    let l:chosen_command = g:rspec_command_0
+  elseif g:command_choice == "1"
+    let l:chosen_command = g:rspec_command_1
+  end
+
+  return l:chosen_command
+endfunction
+
 function! s:RspecCommand()
+  let l:chosen_command = s:GetChosenCommand()
   if s:RspecCommandProvided() && s:IsMacGui()
-    let l:command = s:GuiCommand(g:rspec_command)
+    let l:command = s:GuiCommand(l:chosen_command)
   elseif s:RspecCommandProvided()
-    let l:command = g:rspec_command
+    let l:command = l:chosen_command
   elseif s:IsMacGui()
     let l:command = s:GuiCommand(s:default_command)
   else


### PR DESCRIPTION
This commit adds support for an alternative rspec command.

The use case is when some apps are running a vanilla local rails setup,
and some is using some other setup such as docker.

I found myself changing my rspec_command a lot between docker and
standard, so I updated the plugin to support an alternative command.

My vimrc now looks like this:

    let g:rspec_command = "!bundle exec rspec {spec}"
    let g:rspec_command_0 = "!docker-compose run app bundle exec rspec {spec}"
    map <Leader>t :w<CR> :call RunCurrentSpecFile()<CR>
    map <Leader>s :w<CR> :call RunNearestSpec()<CR>
    map <Leader>l :w<CR> :call RunLastSpec()<CR>
    map <Leader>a :w<CR> :call RunAllSpecs()<CR>
    map <Leader>tx :w<CR> :call RunCurrentSpecFile("0")<CR>
    map <Leader>sx :w<CR> :call RunNearestSpec("0")<CR>
    map <Leader>lx :w<CR> :call RunLastSpec("0")<CR>
    map <Leader>ax :w<CR> :call RunAllSpecs("0")<CR>

I'm a relatively inexperienced developer, and this may not be anything
close to a sensible way of approaching this problem, but it saves me
time and I thought it might be interesting to others. At least an
interesting disucssion.