### PR TITLE
Add support for VimR gui neovim client

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -89,7 +89,7 @@ function! s:ClearCommand()
 endfunction
 
 function! s:IsMacGui()
-  return s:force_gui || (has("gui_running") && has("gui_macvim"))
+  return s:force_gui || (has("gui_running") && has("gui_macvim")) || has("gui_vimr")
 endfunction
 
 function! s:IsWindows()


### PR DESCRIPTION
This PR adds support for running rspec tests from within [VimR](https://github.com/qvacua/vimr) GUI client for neovim, in a similar manner how MacVim support is done.

According to the [documentation](https://github.com/qvacua/vimr/wiki#initvim) `gui_vimr` is a VimR specific setting, which shows that vim is running from VimR.