### PR TITLE
use relative paths instead of absolute paths

### DIFF
--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -73,7 +73,7 @@ function! s:DefaultTerminalCommand()
 endfunction
 
 function! s:CurrentFilePath()
-  return @%
+  return expand("%")
 endfunction
 
 function! s:GuiCommand(command)


### PR DESCRIPTION
When running specs on a specific file via `vim-rspec`, the absolute path is sent to the
runner. This prevents us from running those specs within a docker container.
This commit introduces relative paths instead.