### PR TITLE
Running spec with debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Example:
 let g:rspec_command = "!rspec --drb {spec}"
 ```
 
+If you want running spec with debugger(pry, debugger, etc), just
+declare this in your vim config.
+```vim
+let g:rspec_with_debug = 1
+```
+
 This `g:rspec_command` variable can be used to support any number of test
 runners or pre-loaders. For example, to use
 [Dispatch](https://github.com/tpope/vim-dispatch):

--- a/plugin/rspec.vim
+++ b/plugin/rspec.vim
@@ -2,6 +2,10 @@ let s:plugin_path = expand("<sfile>:p:h:h")
 let s:default_command = "rspec {spec}"
 let s:force_gui = 0
 
+if !exists("g:rspec_with_debug")
+  let g:rspec_with_debug = 0
+endif
+
 if !exists("g:rspec_runner")
   let g:rspec_runner = "os_x_terminal"
 endif
@@ -58,7 +62,11 @@ function! s:RspecCommand()
   elseif s:IsMacGui()
     let l:command = s:GuiCommand(s:default_command)
   else
-    let l:command = s:DefaultTerminalCommand()
+    if g:rspec_with_debug > 0
+      let l:command = s:TerminalCommandWithDebug()
+    else
+      let l:command = s:DefaultTerminalCommand()
+    endif
   endif
 
   return l:command
@@ -70,6 +78,10 @@ endfunction
 
 function! s:DefaultTerminalCommand()
   return "!" . s:ClearCommand() . " && echo " . s:default_command . " && " . s:default_command
+endfunction
+
+function! s:TerminalCommandWithDebug()
+  return "split | terminal "." { " . s:default_command . "  }"
 endfunction
 
 function! s:CurrentFilePath()

--- a/t/rspec_test.vim
+++ b/t/rspec_test.vim
@@ -91,6 +91,25 @@ describe "RunSpecs"
       end
     end
   end
+
+  context "when g:rspec_with_debug is defined"
+    before
+      let g:rspec_with_debug = 1
+    end
+
+    after
+      unlet g:rspec_with_debug
+    end
+
+    it "runs the current spec file at the current line"
+      call Set("s:last_spec_file_with_line", "model_spec.rb:42")
+      call Set("s:last_spec_file", "model_spec.rb")
+
+      call Call("RunNearestSpec")
+
+      Expect Ref("s:rspec_command") == "terminal { rspec controller_spec.rb:5 }"
+    end
+  end
 end
 
 describe "RunCurrentSpecFile"


### PR DESCRIPTION
This pluggin not support for debugging, when i add binding pry to do debugging in spec file. it will ignoring process of debugging.

just declare this in vim config, process debugging will show up
`let g:rspec_with_debug = 1`